### PR TITLE
Add Dockerfile for simple-bank-go application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Build stage
+# Используем официальный образ Go
+FROM golang:1.23.6-alpine3.21 AS builder
+
+# Устанавливаем рабочую директорию
+WORKDIR /app
+
+# Копируем текущий каталог в образ
+COPY . .
+
+# Собираем бинарный файл
+RUN go build -o simple-bank-go main.go
+
+# Run stage
+FROM alpine:3.21
+
+# Устанавливаем рабочую директорию
+WORKDIR /app
+
+# Копируем бинарный файл из builder stage
+COPY --from=builder /app/simple-bank-go .
+
+# Открываем порт 8080
+EXPOSE 8080
+
+# Запускаем бинарный файл
+CMD ["./simple-bank-go"]


### PR DESCRIPTION
- Create multi-stage Docker build for Go application
- Use Alpine Linux as base image
- Configure build and runtime stages
- Expose port 8080 for application access
- Set up CMD to run the compiled binary